### PR TITLE
Exclude docs directory from project/package

### DIFF
--- a/Etch.OrchardCore.Fields.csproj
+++ b/Etch.OrchardCore.Fields.csproj
@@ -14,6 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="docs\**" />
+    <EmbeddedResource Remove="docs\**" />
+    <None Remove="docs\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-beta3-*" />
     <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="1.0.0-beta3-*" />
     <PackageReference Include="OrchardCore.Liquid.Abstractions" Version="1.0.0-beta3-*" />


### PR DESCRIPTION
Noticed the size of the NuGet package was unusually high, this was due to the `docs` directory being included in the build artefact.