### PR TITLE
Update Orchard Core references to target stable build

### DIFF
--- a/Etch.OrchardCore.Fields.csproj
+++ b/Etch.OrchardCore.Fields.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-beta3-*" />
-    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="1.0.0-beta3-*" />
-    <PackageReference Include="OrchardCore.Liquid.Abstractions" Version="1.0.0-beta3-*" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-beta3-*" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-beta3-71077" />
+    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="1.0.0-beta3-71077" />
+    <PackageReference Include="OrchardCore.Liquid.Abstractions" Version="1.0.0-beta3-71077" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-beta3-71077" />
   </ItemGroup>
 
   <Target Name="BuildStaticAssetsForRelease" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' == 'Release'">

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Module for [Orchard Core](https://github.com/OrchardCMS/OrchardCore) that provid
 
 _This module is currently under development and will be made available on NuGet when usable._
 
+## Orchard Core Reference
+
+This module is referencing the beta 3 build of Orchard Core ([`1.0.0-beta3-71077`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-beta3-71077)).
+
 ## Installing
 
 [Download the source](https://github.com/etchuk/Etch.OrchardCore.Fields/archive/master.zip) or clone the repository to your local machine. Add the project to your solution that contains an Orchard Core project and add a reference to Etch.OrchardCore.Fields.


### PR DESCRIPTION
Currently we're targeting the nightly builds in the Orchard Core references. This is a risky strategy as the nightly builds are constantly changing and it's likely breaking changes will be introduced. Instead the module will target the stable builds that are released every couple of months.