### PR TITLE
Fix dictionary field in flows

### DIFF
--- a/Dictionary/Drivers/DictionaryFieldDisplayDriver.cs
+++ b/Dictionary/Drivers/DictionaryFieldDisplayDriver.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.Extensions.Localization;
-using Etch.OrchardCore.Fields.Dictionary.Fields;
+﻿using Etch.OrchardCore.Fields.Dictionary.Fields;
 using Etch.OrchardCore.Fields.Dictionary.Models;
 using Etch.OrchardCore.Fields.Dictionary.Settings;
 using Etch.OrchardCore.Fields.Dictionary.ViewModels;
+using Microsoft.Extensions.Localization;
 using Newtonsoft.Json;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Display.Models;
@@ -54,14 +54,13 @@ namespace Etch.OrchardCore.Fields.Dictionary.Drivers
         public override IDisplayResult Edit(DictionaryField field, BuildFieldEditorContext context)
         {
             var settings = GetSettings(context);
-            var isNew = field.ContentItem.Id == 0;
             return Initialize<EditDictionaryFieldViewModel>(GetEditorShapeType(context), model =>
             {
                 model.Field = field;
                 model.Part = context.ContentPart;
                 model.PartFieldDefinition = context.PartFieldDefinition;
 
-                model.Data = JsonConvert.SerializeObject(isNew ? GetDefaults(context) : field.Data);
+                model.Data = JsonConvert.SerializeObject(field.Data == null ? GetDefaults(context) : field.Data);
 
                 model.MaxEntries = settings?.MaxEntries;
                 model.MinEntries = settings?.MinEntries;
@@ -109,7 +108,7 @@ namespace Etch.OrchardCore.Fields.Dictionary.Drivers
             {
                 return JsonConvert.DeserializeObject<IList<DictionaryItem>>(settingsValue);
             }
-            return null;
+            return new List<DictionaryItem>();
         }
 
         #endregion Helpers

--- a/Dictionary/Fields/DictionaryField.cs
+++ b/Dictionary/Fields/DictionaryField.cs
@@ -6,6 +6,6 @@ namespace Etch.OrchardCore.Fields.Dictionary.Fields
 {
     public class DictionaryField : ContentField
     {
-        public IList<DictionaryItem> Data { get; set; } = new List<DictionaryItem>();
+        public IList<DictionaryItem> Data { get; set; }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1466,12 +1466,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1486,17 +1488,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1613,7 +1618,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1625,6 +1631,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1639,6 +1646,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -1646,12 +1654,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -1670,6 +1680,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -1750,7 +1761,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -1762,6 +1774,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -1883,6 +1896,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
Fixes an issue when the dictionary field is used in a flow by changing how the default values from the settings are applied. Now the `Field` has `Data` as `null` by default and the defaults are applied by the `Edit Get` in the driver if that field value is `null`.

Previously this issue was occurring because the code was detecting `IsNew` by checking `Field.ContentItem.Id` which was `0` in the case of a flow widget.

Fixes #4 