### PR TITLE
Fix Razor precompilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: csharp
 mono: none
-dotnet: 2.2.0
+dist: bionic
+dotnet: 2.2.100
 
 install:
 - dotnet restore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 2.0.0
+dotnet: 2.2.0
 
 install:
 - dotnet restore

--- a/Etch.OrchardCore.Fields.csproj
+++ b/Etch.OrchardCore.Fields.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -25,6 +25,10 @@
     <PackageReference Include="OrchardCore.Liquid.Abstractions" Version="1.0.0-beta3-71077" />
     <PackageReference Include="OrchardCore.Media.Abstractions" Version="1.0.0-beta3-71077" />
     <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-beta3-71077" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
   </ItemGroup>
 
   <Target Name="BuildStaticAssetsForRelease" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' == 'Release'">


### PR DESCRIPTION
Replicate the csproj in the official [Orchard Core templates](https://github.com/OrchardCMS/OrchardCore/blob/dev/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/OrchardCore.Templates.Cms.Module.csproj). Changes were to change the SDK to use Razor and add reference to `Microsoft.AspNetCore.Mvc`.

Also had to update travis to use dotnet 2.2.x.