### PR TITLE
Add useful extension methods for reading/writing content fields

### DIFF
--- a/Etch.OrchardCore.Fields.csproj
+++ b/Etch.OrchardCore.Fields.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.0" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="1.0.0-rc1-10004" />
     <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc1-10004" />
     <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="1.0.0-rc1-10004" />
     <PackageReference Include="OrchardCore.Liquid.Abstractions" Version="1.0.0-rc1-10004" />
@@ -28,6 +29,7 @@
     <PackageReference Include="OrchardCore.Media.Abstractions" Version="1.0.0-rc1-10004" />
     <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc1-10004" />
     <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Taxonomies" Version="1.0.0-rc1-10004" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Extensions/ContentFieldExtensions.cs
+++ b/Extensions/ContentFieldExtensions.cs
@@ -1,0 +1,140 @@
+﻿using OrchardCore.ContentFields.Fields;
+using OrchardCore.ContentManagement;
+using OrchardCore.Media.Fields;
+using OrchardCore.Taxonomies.Fields;
+using System;
+
+namespace Etch.OrchardCore.Fields.Extensions
+{
+    public static class ContentFieldExtensions
+    {
+        #region Boolean Field
+
+        public static bool GetBooleanFieldValue(this ContentPart part, string name)
+        {
+            return part?.Get<BooleanField>(name)?.Value ?? false;
+        }
+
+        public static void SetBooleanField(this ContentPart part, string name, bool value)
+        {
+            var field = part.GetOrCreate<BooleanField>(name);
+            field.Value = value;
+            part.Apply(name, field);
+        }
+
+        #endregion
+
+        #region Date Field
+
+        public static DateTime? GetDateFieldValue(this ContentPart part, string name)
+        {
+            return part?.Get<DateField>(name)?.Value;
+        }
+
+        public static void SetDateField(this ContentPart part, string name, DateTime? value)
+        {
+            var field = part.GetOrCreate<DateField>(name);
+            field.Value = value;
+            part.Apply(name, field);
+        }
+
+        #endregion
+
+        #region Date Time Field
+
+        public static DateTime? GetDateTimeFieldValue(this ContentPart part, string name)
+        {
+            return part?.Get<DateTimeField>(name)?.Value;
+        }
+
+        public static void SetDateTimeField(this ContentPart part, string name, DateTime? value)
+        {
+            var field = part.GetOrCreate<DateTimeField>(name);
+            field.Value = value;
+            part.Apply(name, field);
+        }
+
+        #endregion
+
+        #region Html Field
+
+        public static string GetHtmlFieldValue(this ContentPart part, string name)
+        {
+            return part?.Get<HtmlField>(name)?.Html;
+        }
+
+        public static void SetHtmlField(this ContentPart part, string name, string value)
+        {
+            var field = part.GetOrCreate<HtmlField>(name);
+            field.Html = value;
+            part.Apply(name, field);
+        }
+
+        #endregion
+
+        #region Link Field
+
+        public static string GetLinkFieldValue(this ContentPart part, string name)
+        {
+            return part?.Get<LinkField>(name)?.Url;
+        }
+
+        public static void SetLinkField(this ContentPart part, string name, string value)
+        {
+            var field = part.GetOrCreate<LinkField>(name);
+            field.Url = value;
+            part.Apply(name, field);
+        }
+
+        #endregion
+
+        #region Media Field
+
+        public static string[] GetMediaFieldPaths(this ContentPart contentPart, string name)
+        {
+            return contentPart?.Get<MediaField>(name)?.Paths ?? new string[0];
+        }
+
+        public static void SetMediaFieldPaths(this ContentPart part, string name, string[] paths)
+        {
+            var field = part.GetOrCreate<MediaField>(name);
+            field.Paths = paths;
+            part.Apply(name, field);
+        }
+
+        #endregion
+
+        #region Taxonomy Field
+
+        public static string[] GetTaxonomyFieldTerms(this ContentPart part, string name)
+        {
+            return part?.Get<TaxonomyField>(name)?.TermContentItemIds;
+        }
+
+        public static void SetTaxonomyField(this ContentPart part, string name, string taxonomyId, string[] termIds)
+        {
+            var field = part.GetOrCreate<TaxonomyField>(name);
+            field.TaxonomyContentItemId = taxonomyId;
+            field.TermContentItemIds = termIds;
+            part.Apply(name, field);
+        }
+
+        #endregion
+
+        #region Text Field
+
+        public static string GetTextFieldValue(this ContentPart part, string name)
+        {
+            return part?.Get<TextField>(name)?.Text;
+        }
+
+        public static void SetTextField(this ContentPart part, string name, string value)
+        {
+            var field = part.GetOrCreate<TextField>(name);
+            field.Text = value;
+            part.Apply(name, field);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
We've found we regurlarly add extension methods for reading/writing values on content fields. The extension methods boils the updating of a value down to a single line instead of the few lines necessary to set & apply a content field update.

Haven't catered for all fields, only the primary ones we've added to projects. Will likely add further extension methods for our own content fields defined in this module.