### PR TITLE
Add ability to define site colour palette

### DIFF
--- a/Colour/AdminMenu.cs
+++ b/Colour/AdminMenu.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Localization;
+using OrchardCore.Navigation;
+using System;
+using System.Threading.Tasks;
+
+namespace Etch.OrchardCore.Fields.Colour
+{
+    public class AdminMenu : INavigationProvider
+    {
+        public IStringLocalizer S { get; set; }
+
+        public AdminMenu(IStringLocalizer<AdminMenu> localizer)
+        {
+            S = localizer;
+        }
+
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
+        {
+            if (!string.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.CompletedTask;
+            }
+
+            builder
+                .Add(S["Configuration"], configuration => configuration
+                    .Add(S["Settings"], settings => settings
+                        .Add(S["Colours"], S["Colours"].PrefixPosition(), layers => layers
+                        .AddClass("colours").Id("colours")
+                            .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = Constants.GroupId })
+                            .LocalNav()
+                        )));
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Colour/Constants.cs
+++ b/Colour/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace Etch.OrchardCore.Fields.Colour
+{
+    public static class Constants
+    {
+        public const string GroupId = "Colours";
+    }
+}

--- a/Colour/Drivers/ColourSettingsDisplayDriver.cs
+++ b/Colour/Drivers/ColourSettingsDisplayDriver.cs
@@ -1,0 +1,74 @@
+﻿using Etch.OrchardCore.Fields.Colour.Settings;
+using Etch.OrchardCore.Fields.Colour.ViewModels;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using OrchardCore.DisplayManagement.Entities;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Settings;
+using System.Threading.Tasks;
+
+namespace Etch.OrchardCore.Fields.Colour.Drivers
+{
+    public class ColourSettingsDisplayDriver : SectionDisplayDriver<ISite, ColourSettings>
+    {
+        #region Dependencies
+
+        private readonly IAuthorizationService _authorizationService;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        #endregion
+
+        #region Constructor
+
+        public ColourSettingsDisplayDriver(IAuthorizationService authorizationService, IHttpContextAccessor httpContextAccessor)
+        {
+            _authorizationService = authorizationService;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        #endregion
+
+        #region Overrides
+
+        public override async Task<IDisplayResult> EditAsync(ColourSettings section, BuildEditorContext context)
+        {
+            var user = _httpContextAccessor.HttpContext?.User;
+
+            if (!await _authorizationService.AuthorizeAsync(user, Permissions.ManageColourSettings))
+            {
+                return null;
+            }
+
+            return Initialize<ColourSettingsViewModel>("ColourSettings_Edit", model =>
+            {
+                model.Colours = JsonConvert.SerializeObject(section.Colours);
+            }).Location("Content:3").OnGroup(Constants.GroupId);
+        }
+
+        public override async Task<IDisplayResult> UpdateAsync(ColourSettings section, BuildEditorContext context)
+        {
+            var user = _httpContextAccessor.HttpContext?.User;
+
+            if (!await _authorizationService.AuthorizeAsync(user, Permissions.ManageColourSettings))
+            {
+                return null;
+            }
+
+            if (context.GroupId == Constants.GroupId)
+            {
+                var model = new ColourSettingsViewModel();
+
+                if (await context.Updater.TryUpdateModelAsync(model, Prefix))
+                {
+                    section.Colours = JsonConvert.DeserializeObject<ColourItem[]>(model.Colours);
+                }
+            }
+
+            return await EditAsync(section, context);
+        }
+
+        #endregion
+    }
+}

--- a/Colour/Permissions.cs
+++ b/Colour/Permissions.cs
@@ -1,0 +1,29 @@
+﻿using OrchardCore.Security.Permissions;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Etch.OrchardCore.Fields.Colour
+{
+    public class Permissions : IPermissionProvider
+    {
+        public static readonly Permission ManageColourSettings = new Permission("ManageColours", "Manage Colours");
+
+        public Task<IEnumerable<Permission>> GetPermissionsAsync()
+        {
+            return Task.FromResult(new[] { ManageColourSettings }.AsEnumerable());
+        }
+
+        public IEnumerable<PermissionStereotype> GetDefaultStereotypes()
+        {
+            return new[]
+            {
+                new PermissionStereotype
+                {
+                    Name = "Administrator",
+                    Permissions = new[] { ManageColourSettings }
+                }
+            };
+        }
+    }
+}

--- a/Colour/Settings/ColourFieldSettings.cs
+++ b/Colour/Settings/ColourFieldSettings.cs
@@ -9,5 +9,6 @@ namespace Etch.OrchardCore.Fields.Colour.Settings
         public ColourItem[] Colours { get; set; } = Array.Empty<ColourItem>();
         public string DefaultValue { get; set; }
         public string Hint { get; set; }
+        public bool UseGlobalColours { get; set; } = false;
     }
 }

--- a/Colour/Settings/ColourFieldSettingsDriver.cs
+++ b/Colour/Settings/ColourFieldSettingsDriver.cs
@@ -25,6 +25,7 @@ namespace Etch.OrchardCore.Fields.Colour.Settings
                 viewModel.Colours = JsonConvert.SerializeObject(settings.Colours);
                 viewModel.DefaultValue = settings.DefaultValue;
                 viewModel.Hint = settings.Hint;
+                viewModel.UseGlobalColours = settings.UseGlobalColours;
             })
             .Location("Content");
         }
@@ -41,7 +42,8 @@ namespace Etch.OrchardCore.Fields.Colour.Settings
                     AllowTransparent = viewModel.AllowTransparent,
                     Colours = JsonConvert.DeserializeObject<ColourItem[]>(viewModel.Colours),
                     DefaultValue = viewModel.DefaultValue,
-                    Hint = viewModel.Hint
+                    Hint = viewModel.Hint,
+                    UseGlobalColours = viewModel.UseGlobalColours
                 });
             }
 

--- a/Colour/Settings/ColourSettings.cs
+++ b/Colour/Settings/ColourSettings.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Etch.OrchardCore.Fields.Colour.Settings
+{
+    public class ColourSettings
+    {
+        public ColourItem[] Colours { get; set; } = Array.Empty<ColourItem>();
+    }
+}

--- a/Colour/Startup.cs
+++ b/Colour/Startup.cs
@@ -6,7 +6,10 @@ using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentTypes.Editors;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Modules;
+using OrchardCore.Navigation;
+using OrchardCore.Settings;
 
 namespace Etch.OrchardCore.Fields.Colour
 {
@@ -24,6 +27,9 @@ namespace Etch.OrchardCore.Fields.Colour
                 .UseDisplayDriver<ColourFieldDisplayDriver>();
 
             services.AddScoped<IContentPartFieldDefinitionDisplayDriver, ColourFieldSettingsDriver>();
+
+            services.AddScoped<INavigationProvider, AdminMenu>();
+            services.AddScoped<IDisplayDriver<ISite>, ColourSettingsDisplayDriver>();
         }
     }
 }

--- a/Colour/ViewModels/ColourSettingsViewModel.cs
+++ b/Colour/ViewModels/ColourSettingsViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Etch.OrchardCore.Fields.Colour.ViewModels
+{
+    public class ColourSettingsViewModel
+    {
+        public string Colours { get; set; }
+    }
+}

--- a/Colour/ViewModels/ColoursFieldViewModel.cs
+++ b/Colour/ViewModels/ColoursFieldViewModel.cs
@@ -1,0 +1,9 @@
+﻿namespace Etch.OrchardCore.Fields.Colour.ViewModels
+{
+    public class ColoursFieldViewModel
+    {
+        public string Colours { get; set; }
+
+        public string FieldId { get; set; }
+    }
+}

--- a/Colour/ViewModels/EditColourFieldSettingsViewModel.cs
+++ b/Colour/ViewModels/EditColourFieldSettingsViewModel.cs
@@ -7,5 +7,6 @@
         public string Colours { get; set; }
         public string DefaultValue { get; set; }
         public string Hint { get; set; }
+        public bool UseGlobalColours { get; set; }
     }
 }

--- a/Etch.OrchardCore.Fields.csproj
+++ b/Etch.OrchardCore.Fields.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    <Version>0.11.2-rc2</Version>
+    <Version>0.11.3-rc2</Version>
     <PackageId>Etch.OrchardCore.Fields</PackageId>
     <Title>Etch OrchardCore Fields</Title>
     <Authors>Etch</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "Useful Fields",
     Author = "Etch UK",
     Website = "https://etchuk.com",
-    Version = "0.11.2"
+    Version = "0.11.3"
 )]
 
 [assembly: Feature(

--- a/Views/ColourField.Edit.cshtml
+++ b/Views/ColourField.Edit.cshtml
@@ -1,10 +1,17 @@
 ﻿@model Etch.OrchardCore.Fields.Colour.ViewModels.EditColourFieldViewModel
 
 @using Etch.OrchardCore.Fields.Colour.Settings
+@using OrchardCore.Settings
+@using OrchardCore.Entities
+
+@inject ISiteService _siteService
 
 @{
+    var globalSettings = (await _siteService.GetSiteSettingsAsync()).As<ColourSettings>();
     var settings = Model.PartFieldDefinition.GetSettings<ColourFieldSettings>();
     var placeholder = Guid.NewGuid().ToString().ToLower();
+
+    var colourPalette = settings.UseGlobalColours ? globalSettings.Colours : settings.Colours;
 }
 
 <style asp-src="~/Etch.OrchardCore.Fields/Styles/colour/admin.css" at="Head" asp-append-version="true"></style>
@@ -22,29 +29,29 @@
     }
 
     <div class="row">
-    @foreach (var color in settings.Colours)
-    {
-        <div class="col-md-auto">
-            <button type="button" class="btn rounded-lg mb-1 swatch @(color.Value == Model.Value ? "is-selected" : "") js-colour-btn" data-colour="@color.Value" style="background-color: @color.Value;"></button>
-            <p class="hint">@color.Name</p>
-        </div>
-    }
+        @foreach (var color in colourPalette)
+        {
+            <div class="col-md-auto">
+                <button type="button" class="btn rounded-lg mb-1 swatch @(color.Value == Model.Value ? "is-selected" : "") js-colour-btn" data-colour="@color.Value" style="background-color: @color.Value;"></button>
+                <p class="hint">@color.Name</p>
+            </div>
+        }
 
-    @if (settings.AllowTransparent)
-    {
-    <div class="col-md-auto">
-        <button type="button" class="btn rounded-lg mb-1 swatch @(Model.IsTransparent ? "is-selected" : "") js-transparent-btn" style="background-image: url('@Context.Request.PathBase/Etch.OrchardCore.Fields/Content/background-transparent.png');"></button>
-        <p class="hint">@T["Transparent"]</p>
-    </div>
-    }
+        @if (settings.AllowTransparent)
+        {
+            <div class="col-md-auto">
+                <button type="button" class="btn rounded-lg mb-1 swatch @(Model.IsTransparent ? "is-selected" : "") js-transparent-btn" style="background-image: url('@Context.Request.PathBase/Etch.OrchardCore.Fields/Content/background-transparent.png');"></button>
+                <p class="hint">@T["Transparent"]</p>
+            </div>
+        }
 
-    @if (settings.AllowCustom)
-    {
-        <div class="col-md-auto">
-            <input class="mb-1 swatch @(Model.IsCustomColour ? "is-selected" : "") js-colour-input" type="color" value="@(Model.IsCustomColour ? Model.Value : string.Empty)" />
-            <p class="hint">@T["Specify custom"]</p>
-        </div>
-    }
+        @if (settings.AllowCustom)
+        {
+            <div class="col-md-auto">
+                <input class="mb-1 swatch @(Model.IsCustomColour ? "is-selected" : "") js-colour-input" type="color" value="@(Model.IsCustomColour ? Model.Value : string.Empty)" />
+                <p class="hint">@T["Specify custom"]</p>
+            </div>
+        }
     </div>
 
     <input type="hidden" asp-for="Value" class="js-colour-hidden" />

--- a/Views/ColourFieldSettings.Edit.cshtml
+++ b/Views/ColourFieldSettings.Edit.cshtml
@@ -1,18 +1,6 @@
 ﻿@model Etch.OrchardCore.Fields.Colour.ViewModels.EditColourFieldSettingsViewModel
 
-<script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs"
-        at="Foot"></script>
-<script asp-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.min.js"
-        debug-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.js" asp-name="sortable" at="Foot"></script>
-<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.min.js"
-        debug-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.js" asp-name="vuedraggable"
-        depends-on="vuejs, sortable" at="Foot"></script>
-
-<script asp-src="~/Etch.OrchardCore.Fields/Scripts/dictionary/admin.js" asp-name="dictionary" depends-on="jquery"
-        at="Foot"></script>
-<script at="Foot">
-        initializeDictionaryEditor(document.getElementById('@Html.IdFor(m => m)'));
-</script>
+@using Etch.OrchardCore.Fields.Colour.ViewModels 
 
 <div class="row">
     <div class="form-group col-md-6">
@@ -29,34 +17,7 @@
         <label asp-for="Colours">@T["Colours"]</label>
     </div>
 
-    <div class="row col-sm-6">
-        <div id="@Html.IdFor(m => m)" data-for="@Html.IdFor(m => m.Colours)" asp-validation-class-for="Colours">
-            <input type="hidden" asp-for="Colours" :value="value" data-init="@Model.Colours">
-
-            <draggable tag="ul" class="list-group" v-model="dictionaryItems" handle=".handle">
-                <li v-for="(item, index) in dictionaryItems" class="row no-gutters align-items-center mb-3">
-                    <div class="col col-md-auto ml-2 mr-2">
-                        <button type="button" class="btn btn-light btn-sm handle"><span class="fa fa-align-justify"></span></button>
-                    </div>
-                    <div class="col ml-2 mr-2">
-                        <input class="form-control" asp-validation-class-for="Colours" placeholder="Name" type="text" :ref="'name'" v-model="item.name" v-on:keydown.enter.prevent="nextField('name', index)" v-on:keydown.backspace="handleBackspace('name', index, $event)" v-on:keydown.up.prevent="handleUp('name', index)" v-on:keydown.down.prevent="handleDown('name', index)" />
-                    </div>
-                    <div class="col ml-2 mr-2">
-                        <input class="form-control" asp-validation-class-for="Colours" placeholder="Value" type="text" :ref="'value'" v-model="item.value" v-on:keydown.enter.prevent="nextField('value', index)" v-on:keydown.backspace="handleBackspace('value', index, $event)" v-on:keydown.up.prevent="handleUp('value', index)" v-on:keydown.down.prevent="handleDown('value', index)" />
-                    </div>
-                    <div class="col col-md-auto ml-2 mr-2">
-                        <button v-on:click="remove(index)" class="btn btn-danger btn-sm" type="button">
-                            <span class="fa fa-trash-alt">&nbsp;</span>
-                        </button>
-                    </div>
-                </li>
-            </draggable>
-
-            <p v-if="!hasEntries" class="hint">@T["No colours yet, add one below."]</p>
-
-            <button v-on:click="add" class="btn btn-secondary btn-sm" type="button" :disabled="false"><span class="fa fa-plus">&nbsp;</span> @T["Add Colour"]</button>
-        </div>
-    </div>
+    <partial name="./Shared/ColoursEditor.cshtml" model="@(new ColoursFieldViewModel { Colours = Model.Colours, FieldId = Html.IdFor(x => x.Colours) })" />
 </div>
 
 <div class="row">

--- a/Views/ColourSettings.Edit.cshtml
+++ b/Views/ColourSettings.Edit.cshtml
@@ -1,54 +1,15 @@
 ﻿@model Etch.OrchardCore.Fields.Colour.ViewModels.ColourSettingsViewModel
 
-<script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs"
-        at="Foot"></script>
-<script asp-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.min.js"
-        debug-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.js" asp-name="sortable" at="Foot"></script>
-<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.min.js"
-        debug-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.js" asp-name="vuedraggable"
-        depends-on="vuejs, sortable" at="Foot"></script>
-
-<script asp-src="~/Etch.OrchardCore.Fields/Scripts/dictionary/admin.js" asp-name="dictionary" depends-on="jquery"
-        at="Foot"></script>
-<script at="Foot">
-        initializeDictionaryEditor(document.getElementById('@Html.IdFor(m => m)'));
-</script>
+@using Etch.OrchardCore.Fields.Colour.ViewModels
 
 <div class="form-group">
     <div class="row col-sm-6">
         <label asp-for="Colours">@T["Colours"]</label>
     </div>
 
-    <div class="row col-xs-12">
+    <div class="row col-sm-12">
         <p class="hint">@T["Define colour palette used by colour fields configured to use global settings."]</p>
     </div>
 
-    <div class="row col-sm-6">
-        <div id="@Html.IdFor(m => m)" data-for="@Html.IdFor(m => m.Colours)" asp-validation-class-for="Colours">
-            <input type="hidden" asp-for="Colours" :value="value" data-init="@Model.Colours">
-
-            <draggable tag="ul" class="list-group" v-model="dictionaryItems" handle=".handle">
-                <li v-for="(item, index) in dictionaryItems" class="row no-gutters align-items-center mb-3">
-                    <div class="col col-md-auto ml-2 mr-2">
-                        <button type="button" class="btn btn-light btn-sm handle"><span class="fa fa-align-justify"></span></button>
-                    </div>
-                    <div class="col ml-2 mr-2">
-                        <input class="form-control" asp-validation-class-for="Colours" placeholder="Name" type="text" :ref="'name'" v-model="item.name" v-on:keydown.enter.prevent="nextField('name', index)" v-on:keydown.backspace="handleBackspace('name', index, $event)" v-on:keydown.up.prevent="handleUp('name', index)" v-on:keydown.down.prevent="handleDown('name', index)" />
-                    </div>
-                    <div class="col ml-2 mr-2">
-                        <input class="form-control" asp-validation-class-for="Colours" placeholder="Value" type="text" :ref="'value'" v-model="item.value" v-on:keydown.enter.prevent="nextField('value', index)" v-on:keydown.backspace="handleBackspace('value', index, $event)" v-on:keydown.up.prevent="handleUp('value', index)" v-on:keydown.down.prevent="handleDown('value', index)" />
-                    </div>
-                    <div class="col col-md-auto ml-2 mr-2">
-                        <button v-on:click="remove(index)" class="btn btn-danger btn-sm" type="button">
-                            <span class="fa fa-trash-alt">&nbsp;</span>
-                        </button>
-                    </div>
-                </li>
-            </draggable>
-
-            <p v-if="!hasEntries" class="hint">@T["No colours yet, add one below."]</p>
-
-            <button v-on:click="add" class="btn btn-secondary btn-sm" type="button" :disabled="false"><span class="fa fa-plus">&nbsp;</span> @T["Add Colour"]</button>
-        </div>
-    </div>
+    <partial name="./Shared/ColoursEditor.cshtml" model="@(new ColoursFieldViewModel { Colours = Model.Colours, FieldId = Html.IdFor(x => x.Colours) })" />
 </div>

--- a/Views/ColourSettings.Edit.cshtml
+++ b/Views/ColourSettings.Edit.cshtml
@@ -1,4 +1,4 @@
-﻿@model Etch.OrchardCore.Fields.Colour.ViewModels.EditColourFieldSettingsViewModel
+﻿@model Etch.OrchardCore.Fields.Colour.ViewModels.ColourSettingsViewModel
 
 <script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs"
         at="Foot"></script>
@@ -14,19 +14,13 @@
         initializeDictionaryEditor(document.getElementById('@Html.IdFor(m => m)'));
 </script>
 
-<div class="row">
-    <div class="form-group col-md-6">
-        <div class="custom-control custom-checkbox">
-            <input type="checkbox" class="custom-control-input" asp-for="UseGlobalColours" checked="@Model.UseGlobalColours">
-            <label class="custom-control-label" asp-for="UseGlobalColours">@T["Use Site Colour Palette"]</label>
-            <span class="hint">@T["Use colours defined within site settings."]</span>
-        </div>
-    </div>
-</div>
-
 <div class="form-group">
     <div class="row col-sm-6">
         <label asp-for="Colours">@T["Colours"]</label>
+    </div>
+
+    <div class="row col-xs-12">
+        <p class="hint">@T["Define colour palette used by colour fields configured to use global settings."]</p>
     </div>
 
     <div class="row col-sm-6">
@@ -56,41 +50,5 @@
 
             <button v-on:click="add" class="btn btn-secondary btn-sm" type="button" :disabled="false"><span class="fa fa-plus">&nbsp;</span> @T["Add Colour"]</button>
         </div>
-    </div>
-</div>
-
-<div class="row">
-    <div class="form-group col-md-6">
-        <div class="custom-control custom-checkbox">
-            <input type="checkbox" class="custom-control-input" asp-for="AllowTransparent" checked="@Model.AllowTransparent">
-            <label class="custom-control-label" asp-for="AllowTransparent">@T["Allow Transparent"]</label>
-            <span class="hint">@T["Include option for choosing transparent as a colour."]</span>
-        </div>
-    </div>
-</div>
-
-<div class="row">
-    <div class="form-group col-md-6">
-        <div class="custom-control custom-checkbox">
-            <input type="checkbox" class="custom-control-input" asp-for="AllowCustom" checked="@Model.AllowCustom">
-            <label class="custom-control-label" asp-for="AllowCustom">@T["Allow Custom"]</label>
-            <span class="hint">@T["Include ability to specify custom colour."]</span>
-        </div>
-    </div>
-</div>
-
-<div class="form-group">
-    <div class="row col-sm-6">
-        <label asp-for="DefaultValue">@T["Default Value"]</label>
-        <input asp-for="DefaultValue" class="form-control" />
-        <span class="hint">@T["Default value when no colour has been defined."]</span>
-    </div>
-</div>
-
-<div class="form-group">
-    <div class="row col-sm-6">
-        <label asp-for="Hint">@T["Hint"]</label>
-        <textarea asp-for="Hint" rows="2" class="form-control"></textarea>
-        <span class="hint">@T["The hint text to display for this field on the editor."]</span>
     </div>
 </div>

--- a/Views/NavigationItemText-colours.Id.cshtml
+++ b/Views/NavigationItemText-colours.Id.cshtml
@@ -1,0 +1,1 @@
+﻿<span class="icon"><i class="fa fa-palette" aria-hidden="true"></i></span><span class="title">@T["Colours"]</span>

--- a/Views/Shared/ColoursEditor.cshtml
+++ b/Views/Shared/ColoursEditor.cshtml
@@ -1,0 +1,48 @@
+﻿@model Etch.OrchardCore.Fields.Colour.ViewModels.ColoursFieldViewModel
+
+@{ 
+    var uid = Guid.NewGuid();
+}
+
+<script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs"
+        at="Foot"></script>
+<script asp-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.min.js"
+        debug-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.js" asp-name="sortable" at="Foot"></script>
+<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.min.js"
+        debug-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.js" asp-name="vuedraggable"
+        depends-on="vuejs, sortable" at="Foot"></script>
+
+<script asp-src="~/Etch.OrchardCore.Fields/Scripts/dictionary/admin.js" asp-name="dictionary" depends-on="jquery"
+        at="Foot"></script>
+<script at="Foot">
+        initializeDictionaryEditor(document.getElementById('@uid'));
+</script>
+
+<div class="row col-sm-6">
+    <div id="@uid" data-for="@Model.FieldId" asp-validation-class-for="Colours">
+        <input type="hidden" asp-for="Colours" :value="value" data-init="@Model.Colours">
+
+        <draggable tag="ul" class="list-group" v-model="dictionaryItems" handle=".handle">
+            <li v-for="(item, index) in dictionaryItems" class="row no-gutters align-items-center mb-3">
+                <div class="col col-md-auto ml-2 mr-2">
+                    <button type="button" class="btn btn-light btn-sm handle"><span class="fa fa-align-justify"></span></button>
+                </div>
+                <div class="col ml-2 mr-2">
+                    <input class="form-control" asp-validation-class-for="Colours" placeholder="Name" type="text" :ref="'name'" v-model="item.name" v-on:keydown.enter.prevent="nextField('name', index)" v-on:keydown.backspace="handleBackspace('name', index, $event)" v-on:keydown.up.prevent="handleUp('name', index)" v-on:keydown.down.prevent="handleDown('name', index)" />
+                </div>
+                <div class="col ml-2 mr-2">
+                    <input class="form-control" asp-validation-class-for="Colours" placeholder="Value" type="text" :ref="'value'" v-model="item.value" v-on:keydown.enter.prevent="nextField('value', index)" v-on:keydown.backspace="handleBackspace('value', index, $event)" v-on:keydown.up.prevent="handleUp('value', index)" v-on:keydown.down.prevent="handleDown('value', index)" />
+                </div>
+                <div class="col col-md-auto ml-2 mr-2">
+                    <button v-on:click="remove(index)" class="btn btn-danger btn-sm" type="button">
+                        <span class="fa fa-trash-alt">&nbsp;</span>
+                    </button>
+                </div>
+            </li>
+        </draggable>
+
+        <p v-if="!hasEntries" class="hint">@T["No colours yet, add one below."]</p>
+
+        <button v-on:click="add" class="btn btn-secondary btn-sm" type="button" :disabled="false"><span class="fa fa-plus">&nbsp;</span> @T["Add Colour"]</button>
+    </div>
+</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "etch.orchardcore.fields",
-    "version": "0.11.2",
+    "version": "0.11.3",
     "description": "Module for Orchard Core that provides useful content fields.",
     "scripts": {
         "build": "webpack",


### PR DESCRIPTION
Add new settings for defining a set of colours that represent the colour palette for the site. This is utilised by a new setting on the colour field for using colours defined within the site settings.

Resolves #70.