### PR TITLE
Add default field CSS classes

### DIFF
--- a/Etch.OrchardCore.Fields.csproj
+++ b/Etch.OrchardCore.Fields.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    <Version>0.11.5-rc2</Version>
+    <Version>0.11.6-rc2</Version>
     <PackageId>Etch.OrchardCore.Fields</PackageId>
     <Title>Etch OrchardCore Fields</Title>
     <Authors>Etch</Authors>

--- a/Extensions/ContentFieldExtensions.cs
+++ b/Extensions/ContentFieldExtensions.cs
@@ -1,8 +1,11 @@
 ﻿using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.Media.Fields;
 using OrchardCore.Taxonomies.Fields;
 using System;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Etch.OrchardCore.Fields.Extensions
 {
@@ -133,6 +136,26 @@ namespace Etch.OrchardCore.Fields.Extensions
             var field = part.GetOrCreate<TextField>(name);
             field.Text = value;
             part.Apply(name, field);
+        }
+
+        #endregion
+
+        #region Generic
+
+        public static string HtmlClassify(this ContentPartFieldDefinition contentPartFieldDefinition)
+        {
+            var stringBuilder = new StringBuilder();
+
+            stringBuilder.Append($"{ToHyphenCase(contentPartFieldDefinition.PartDefinition.Name)}-");
+            stringBuilder.Append($"{ToHyphenCase(contentPartFieldDefinition.FieldDefinition.Name.Replace("Field", string.Empty))}");
+            stringBuilder.Append($" {stringBuilder}--{ToHyphenCase(contentPartFieldDefinition.Name)}");
+
+            return stringBuilder.ToString();
+        }
+
+        private static string ToHyphenCase(string value)
+        {
+            return Regex.Replace(value, @"([a-z])([A-Z])", "$1-$2").ToLower();
         }
 
         #endregion

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "Useful Fields",
     Author = "Etch UK",
     Website = "https://etchuk.com",
-    Version = "0.11.5"
+    Version = "0.11.6"
 )]
 
 [assembly: Feature(

--- a/Views/CodeField.cshtml
+++ b/Views/CodeField.cshtml
@@ -1,3 +1,3 @@
 ﻿@model Etch.OrchardCore.Fields.Code.ViewModels.DisplayCodeFieldViewModel
 
-<code><pre>@Model.Value</pre></code>
+<code class="@Model.PartFieldDefinition.HtmlClassify()"><pre>@Model.Value</pre></code>

--- a/Views/DictionaryField.cshtml
+++ b/Views/DictionaryField.cshtml
@@ -1,13 +1,9 @@
 @model Etch.OrchardCore.Fields.Dictionary.ViewModels.DisplayDictionaryFieldViewModel
-@using OrchardCore.Mvc.Utilities;
 
-@{
-    var name = (Model.PartFieldDefinition.PartDefinition.Name + "-" + Model.PartFieldDefinition.Name).HtmlClassify();
-}
 
 @if (Model.Data != null)
 {
-    <ul class="dictionary list field field--@name">
+    <ul class="dictionary list @Model.PartFieldDefinition.HtmlClassify()">
         @foreach (var dictionaryItem in Model.Data)
         {
             <li class="dictionary__item">

--- a/Views/EventbriteField.cshtml
+++ b/Views/EventbriteField.cshtml
@@ -1,11 +1,6 @@
 ﻿@model Etch.OrchardCore.Fields.Eventbrite.ViewModels.DisplayEventbriteFieldViewModel
-@using OrchardCore.Mvc.Utilities;
 
-@{
-    var name = (Model.PartFieldDefinition.PartDefinition.Name + "-" + Model.PartFieldDefinition.Name).HtmlClassify();
-}
-
-<ul class="field field-type-eventbrite field-name-@name">
+<ul class="@Model.PartFieldDefinition.HtmlClassify()">
     <li><em>Event Name:</em> @Model.Data.Name</li>
     <li><em>Start:</em> @Model.Data.StartUtc</li>
     <li><em>End:</em> @Model.Data.EndUtc</li>

--- a/Views/MultiSelectField.cshtml
+++ b/Views/MultiSelectField.cshtml
@@ -2,7 +2,7 @@
 
 @if (Model.HasValues)
 {
-    <ul>
+    <ul class="@Model.PartFieldDefinition.HtmlClassify()">
         @foreach (var value in Model.SelectedValues)
         {
             <li>@value</li>

--- a/Views/ResponsiveMediaField.cshtml
+++ b/Views/ResponsiveMediaField.cshtml
@@ -1,14 +1,9 @@
 ﻿@model Etch.OrchardCore.Fields.ResponsiveMedia.ViewModels.DisplayResponsiveMediaFieldViewModel
 
-@{
-    var cssClass = $"{Model.PartFieldDefinition.PartDefinition.Name.ToLower()}__media--{Model.PartFieldDefinition.Name.ToLower()}";
-    var listClass = $"{Model.PartFieldDefinition.PartDefinition.Name.ToLower()}__media-list--{Model.PartFieldDefinition.Name.ToLower()}";
-}
-
 @if (Model.HasMedia)
 {
     if (Model.Media.Count == 1) {
-        <picture class="@cssClass">
+        <picture class="@Model.PartFieldDefinition.HtmlClassify()">
             @foreach (var sourceSet in Model.Media[0].Sources)
             {
                 <source srcset="@sourceSet.Url" media="@($"(min-width: {sourceSet.Breakpoint}px)")" />
@@ -17,11 +12,11 @@
             <img src="@Model.Media[0].SmallestImageUrl" loading="lazy" alt="@Model.Media[0].MediaText" />
         </picture>
     } else {
-        <ul class="@listClass">
+        <ul class="@Model.PartFieldDefinition.HtmlClassify()--list">
             @foreach (var media in Model.Media)
             {
                 <li>
-                    <picture class="@cssClass">
+                    <picture class="@Model.PartFieldDefinition.HtmlClassify()">
                         @foreach (var sourceSet in media.Sources)
                         {
                             <source srcset="@sourceSet.Url" media="@($"(min-width: {sourceSet.Breakpoint}px)")" />

--- a/Views/ValuesField.cshtml
+++ b/Views/ValuesField.cshtml
@@ -1,16 +1,14 @@
 @model Etch.OrchardCore.Fields.Values.ViewModels.DisplayValuesFieldViewModel
 
-@using OrchardCore.Mvc.Utilities;
 @using Etch.OrchardCore.Fields.Values.Settings
 
 @{
-    var modifier = Model.PartFieldDefinition.Name.HtmlClassify();
     var settings = Model.PartFieldDefinition.GetSettings<ValuesFieldSettings>();
 }
 
 @if (Model.Data.Any())
 {
-    <ul class="list list--@modifier">
+    <ul class="list @Model.PartFieldDefinition.HtmlClassify()">
     @foreach (var item in Model.Data)
     {
         <li class="list__item">@item</li>

--- a/Views/_ViewImports.cshtml
+++ b/Views/_ViewImports.cshtml
@@ -1,7 +1,9 @@
 ﻿@inherits OrchardCore.DisplayManagement.Razor.RazorPage<TModel>
 
+@using Etch.OrchardCore.Fields.Extensions
 @using OrchardCore.ContentManagement.Metadata.Models
 @using OrchardCore.DisplayManagement
+
 
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, OrchardCore.DisplayManagement

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "etch.orchardcore.fields",
-    "version": "0.11.5",
+    "version": "0.11.6",
     "description": "Module for Orchard Core that provides useful content fields.",
     "scripts": {
         "build": "webpack",


### PR DESCRIPTION
Expanding upon [Adam's PR](https://github.com/EtchUK/Etch.OrchardCore.Fields/pull/81), this introduces a generic approach for adding CSS classes to all the custom fields provided by this module that render an output. `Classify` takes the part field definition to generate a CSS class names that contain a base class and a modifier. The base CSS class is composed of the content part name and field type. Then the modifier contains the name of the field on the part. As an example, if you have a content part named "Foo" that contain a `CodeField` named "Bar", the CSS class output will be `foo-code foo-code--bar`.