### PR TITLE
Exclude part from class name

### DIFF
--- a/Etch.OrchardCore.Fields.csproj
+++ b/Etch.OrchardCore.Fields.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    <Version>0.11.6-rc2</Version>
+    <Version>0.11.7-rc2</Version>
     <PackageId>Etch.OrchardCore.Fields</PackageId>
     <Title>Etch OrchardCore Fields</Title>
     <Authors>Etch</Authors>

--- a/Extensions/ContentFieldExtensions.cs
+++ b/Extensions/ContentFieldExtensions.cs
@@ -144,10 +144,13 @@ namespace Etch.OrchardCore.Fields.Extensions
 
         public static string HtmlClassify(this ContentPartFieldDefinition contentPartFieldDefinition)
         {
+            var partName = contentPartFieldDefinition.PartDefinition.Name;
+            var fieldName = contentPartFieldDefinition.FieldDefinition.Name;
+
             var stringBuilder = new StringBuilder();
 
-            stringBuilder.Append($"{ToHyphenCase(contentPartFieldDefinition.PartDefinition.Name)}-");
-            stringBuilder.Append($"{ToHyphenCase(contentPartFieldDefinition.FieldDefinition.Name.Replace("Field", string.Empty))}");
+            stringBuilder.Append($"{ToHyphenCase(partName.EndsWith("Part") ? partName.Substring(0, partName.Length - 4) : partName)}-");
+            stringBuilder.Append($"{ToHyphenCase(fieldName.EndsWith("Field") ? fieldName.Substring(0, fieldName.Length - 5) : fieldName)}");
             stringBuilder.Append($" {stringBuilder}--{ToHyphenCase(contentPartFieldDefinition.Name)}");
 
             return stringBuilder.ToString();

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "Useful Fields",
     Author = "Etch UK",
     Website = "https://etchuk.com",
-    Version = "0.11.6"
+    Version = "0.11.7"
 )]
 
 [assembly: Feature(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "etch.orchardcore.fields",
-    "version": "0.11.6",
+    "version": "0.11.7",
     "description": "Module for Orchard Core that provides useful content fields.",
     "scripts": {
         "build": "webpack",


### PR DESCRIPTION
Small tweak to the generated CSS class names to ensure "Part" is ignored on the part name. Changed the logic to only strip "Part" & "Field" off the end of the definition name to ensure there isn't any weird issues where a definition name contains "Field" or "Part" as part of it.