### PR TITLE
Fix issue where images with spaces wouldn't render in sourceset

### DIFF
--- a/Etch.OrchardCore.Fields.csproj
+++ b/Etch.OrchardCore.Fields.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <PackageId>Etch.OrchardCore.Fields</PackageId>
     <Title>Etch OrchardCore Fields</Title>
     <Authors>Etch</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.Modules.Manifest;
     Name = "Useful Fields",
     Author = "Etch UK",
     Website = "https://etchuk.com",
-    Version = "1.2.1"
+    Version = "1.2.2"
 )]
 
 [assembly: Feature(

--- a/ResponsiveMedia/Models/ResponsiveMediaItem.cs
+++ b/ResponsiveMedia/Models/ResponsiveMediaItem.cs
@@ -37,7 +37,7 @@ namespace Etch.OrchardCore.Fields.ResponsiveMedia.Models
 
                 if (media != null)
                 {
-                    lastMedia = new ResponsiveMediaSource { Breakpoint = nextBreakpoint + 1, Url = media.Url };
+                    lastMedia = new ResponsiveMediaSource { Breakpoint = nextBreakpoint + 1, Url = Uri.EscapeUriString(media.Url) };
                     sourceSets.Add(lastMedia);
                     continue;
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "etch.orchardcore.fields",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Module for Orchard Core that provides useful content fields.",
     "scripts": {
         "build": "webpack",


### PR DESCRIPTION
Images with spaces in their filenames wouldn't be used within a `sourceset` that's rendered by the responsive media field. Re-added the Uri.EscapeUriString for now but as this method is obsolete an alternative method will need to be used in the future.