### PR TITLE
Add permission to colour field admin menu settings

### DIFF
--- a/Colour/AdminMenu.cs
+++ b/Colour/AdminMenu.cs
@@ -27,6 +27,7 @@ namespace Etch.OrchardCore.Fields.Colour
                         .Add(S["Colours"], S["Colours"].PrefixPosition(), layers => layers
                         .AddClass("colours").Id("colours")
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = Constants.GroupId })
+                            .Permission(Permissions.ManageColourSettings)
                             .LocalNav()
                         )));
 


### PR DESCRIPTION
The link to the setting appears on the admin menu even if the user doesn't have permission to change it so it just results in a 403.

This change removes the link to the setting when the user is not allowed to change it.